### PR TITLE
Using time.perf_counter module

### DIFF
--- a/molecular/operators.py
+++ b/molecular/operators.py
@@ -1,4 +1,4 @@
-from time import clock, sleep, strftime, gmtime, time
+from time import perf_counter as clock, sleep, strftime, gmtime, time
 
 import bpy
 from mathutils import Vector

--- a/sources/core.pyx
+++ b/sources/core.pyx
@@ -7,7 +7,7 @@
 
 
 cimport cython
-from time import clock
+from time import perf_counter as clock
 from cython.parallel import parallel, prange, threadid
 from libc.stdlib cimport malloc, realloc, free, rand, srand, abs
 


### PR DESCRIPTION
Hello, I was trying to install this fantastic add-on on the new blender 2.90 version (for Linux) but, when trying to enable it, I got stuck with this error:

```
Exception in module register(): /home/marbasso/.config/blender/2.90/scripts/addons/molecular/__init__.py
Traceback (most recent call last):
  File "/usr/share/blender/2.90/scripts/modules/addon_utils.py", line 382, in enable
    mod.register()
  File "/home/marbasso/.config/blender/2.90/scripts/addons/molecular/__init__.py", line 42, in register
    from . import properties, ui, operators
  File "/home/marbasso/.config/blender/2.90/scripts/addons/molecular/operators.py", line 1, in <module>
    from time import clock, sleep, strftime, gmtime, time
ImportError: cannot import name 'clock' from 'time' (unknown location)
```

As the first try, I downloaded the Blender 2.83.7 LTS version (for Linux), but the error was the same.
Then, I tried to clone this Molecular Script repository and compile myself using the `make_release.py` file but always received the same error during the add-on enable.
So I tried to investigate a bit more and found a similar error on other [Python-based repositories](https://github.com/PyTables/PyTables/issues/744#issue-466721093) (not related to Blender), in which I found the [possible cause](https://www.webucator.com/blog/2015/08/python-clocks-explained/).

In fact, according to [Python 3.8 documentation](https://docs.python.org/3/whatsnew/3.8.html):

> The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. (Contributed by Matthias Bussonnier in [bpo-36895](https://bugs.python.org/issue36895).) 

I verified my Python installation and it is the 3.8.5 version, this may be the source of the problem. I didn't want to downgrade, so I started to modify the code to try to solve the issue. I wanted to modify as few parts as possible to keep the main code untouched, so I just replaced all the lines importing `time.clock` with lines importing the new `time.perf_counter` using the old "clock" name.
In other words, I did the following substitution:

`from time import clock`  ->  `from time import perf_counter as clock`

In this way, all the original calls to the `clock` function actually turn to be a call to the new `perf_counter` function. After compiling, installing and enabling, the add-on works like a charm!

Is it safe to do a merge in the master branch? Since the `clock` module has been removed, this problem might be more frequent in the future. However, I don't know what is the impact on older versions of Blender and/or Python. 